### PR TITLE
Correct platform label from React Native to Flutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ NSLocationWhenInUseUsageDescription - describe why your app needs access to the 
 
 ## Usage
 
-To start KYC, import Dojah in your React Native code, and launch Dojah Screen
+To start KYC, import Dojah in your Flutter code, and launch Dojah Screen.
 
 ```dart
 import 'package:dojah_kyc_sdk_flutter/dojah_kyc_sdk_flutter.dart';


### PR DESCRIPTION
This pull request updates the platform information to accurately reflect that the package is built for Flutter, not React Native.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects platform reference from React Native to Flutter in `README.md`.
> 
>   - **Documentation**:
>     - Corrects platform reference from React Native to Flutter in `README.md` under the Usage section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dojah-inc%2FDojah-flutter-sdk&utm_source=github&utm_medium=referral)<sup> for 7b0b58db73adeccb66e9e73f88836491eedf2f7f. You can [customize](https://app.ellipsis.dev/dojah-inc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->