### PR TITLE
fix(android): resolve Java 17 compatibility for Dojah Flutter SDK

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,8 +24,13 @@ android {
     compileSdk = 35
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+        coreLibraryDesugaringEnabled true
+    }
+
+    kotlinOptions {
+        jvmTarget = 17
     }
 
     defaultConfig {
@@ -50,6 +55,7 @@ android {
         testImplementation("org.mockito:mockito-core:5.0.0")
         implementation 'com.github.dojah-inc:sdk-kotlin:v0.3.6'
 //        implementation 'com.github.dojah-inc:sdk-kotlin:v0.1.1-dev'
+        coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.5"
     }
 
     testOptions {

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -25,4 +25,4 @@
 -keep class * extends io.flutter.plugin.common.PluginRegistry { *; }
 -keep class * extends io.flutter.plugins.** { *; }
 -keep class * implements io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback { *; }
-
+-dontwarn java.lang.invoke.StringConcatFactory

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -11,13 +11,13 @@ android {
     ndkVersion = "28.2.13676358"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
         coreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/example/android/app/proguard-rules.pro
+++ b/example/android/app/proguard-rules.pro
@@ -105,4 +105,4 @@
 -dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
 -dontwarn org.conscrypt.Conscrypt$Version
 -dontwarn org.conscrypt.Conscrypt
-
+-dontwarn java.lang.invoke.StringConcatFactory

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -15,7 +15,7 @@ subprojects {
     plugins.withId("org.jetbrains.kotlin.android") {
         tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
             kotlinOptions {
-                jvmTarget = JavaVersion.VERSION_1_8.toString()
+                jvmTarget = JavaVersion.VERSION_17.toString()
             }
         }
     }


### PR DESCRIPTION
Updated the Android build configuration to resolve Java 17 compatibility issues with the Dojah Flutter SDK. This ensures consistent JVM target settings across Java and Kotlin compilation tasks, preventing build failures caused by mismatched Java versions and improving compatibility with newer Android Gradle Plugin and JDK versions.